### PR TITLE
setup.py with utf8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 from setuptools import find_packages, setup
 
 with open('README.md') as f:


### PR DESCRIPTION
the commit fix the error

```
python setup.py test
  File "setup.py", line 14
SyntaxError: Non-ASCII character '\xc3' in file setup.py on line 14, but no encoding declared; see http://www.python.org/peps/pep-0263.html for details
```

(produced by the name "José")
